### PR TITLE
strip double quote in path

### DIFF
--- a/gyp/pylib/gyp/generator/make.py
+++ b/gyp/pylib/gyp/generator/make.py
@@ -2484,6 +2484,8 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
     def Absolutify(self, path):
         """Convert a subdirectory-relative path into a base-relative path.
         Skips over paths that contain variables."""
+        """In MINGW node -p return a path with double quote"""
+        path = path.strip('"')
         if "$(" in path:
             # Don't call normpath in this case, as it might collapse the
             # path too aggressively if it features '..'. However it's still


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm run lint && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
related issue: https://github.com/nodejs/node-gyp/issues/3120
<!-- Provide a description of the change -->

## Summary by Sourcery

Bug Fixes:
- Remove surrounding double quotes in paths to handle MINGW node -p output